### PR TITLE
[pascalTriangle.II] mistakes

### DIFF
--- a/src/pascalTriangle/pascalTriangle.II.cpp
+++ b/src/pascalTriangle/pascalTriangle.II.cpp
@@ -27,7 +27,7 @@ vector<int> getRow(int rowIndex) {
            v.push_back(0);
     }
 
-    for (int i=1; i<rowIndex; i++){
+    for (int i=0; i<rowIndex; i++){
         for(int j=i+1; j>0; j--){
            v[j] += v[j-1];
         } 


### PR DESCRIPTION
In code

```
for (int i=0; i<rowIndex; i++){
        for(int j=i+1; j>0; j--){
           v[j] += v[j-1];
        } 
    }
```

when `i` equals `rowIndex-1` and `j` equals `rowIndex`, the `v` doesn't have the element at `j`.
