### PR TITLE
ADD: solution three for TenthLine

### DIFF
--- a/shell/TenthLine.sh
+++ b/shell/TenthLine.sh
@@ -40,3 +40,5 @@ awk 'NR==10{print $0}' file.txt
 # Solution Two
 sed -n '10p' file.txt
 
+# Solution Three
+head -10 file.txt | tail -1


### PR DESCRIPTION
Shell for Tenth Line

```bash
head -10 file.txt | tail -1
```

It seems that if file.txt contains  less than 10 lines, the last line will be the output. Oops...