### PR TITLE
Fix possible out of bound array access

### DIFF
--- a/algorithms/cpp/UTF8Validation/UTF8Validation.cpp
+++ b/algorithms/cpp/UTF8Validation/UTF8Validation.cpp
@@ -67,6 +67,10 @@ public:
                 return false;
             }
             
+            // invalid utf-8 as it doesn't have enough 10xxxxxx
+            if (i + len > data.size()) {
+                return false;
+            }
             
             for (int j=i+1; j < i+len; j++) { //checking 10xxxxxx
                 if ( (data[j] & 0xC0) != 0x80 ) {
@@ -75,11 +79,6 @@ public:
             }
             
             i += len ;
-            
-            if (i > data.size()) {
-                return false;
-            }
-            
         }
         return true;
     }


### PR DESCRIPTION
Should check array size before accessing the second to fourth bytes of
utf8 as there might be not enough data left in the array.